### PR TITLE
pbpy: add a run_with_stdin() wrapper and join command list for all OSes

### DIFF
--- a/pbpy/pbgit.py
+++ b/pbpy/pbgit.py
@@ -101,7 +101,7 @@ def get_lockables():
     if proc.returncode:
         return None
     lfs_files = proc.stdout
-    proc = subprocess.run([get_git_executable(), "check-attr", "lockable", "--stdin"], input=lfs_files, capture_output=True, text=True, shell=True)
+    proc = pbtools.run_with_stdin([get_git_executable(), "check-attr", "lockable", "--stdin"], input=lfs_files)
     attrs = proc.stdout.splitlines()
     lockables = set()
     for attr in attrs:
@@ -223,7 +223,7 @@ def get_credentials():
         creds += f"username={repo_url.username}\n"
     creds += "\n"
 
-    proc = subprocess.run([get_gcm_executable(), "get"], input=creds, capture_output=True, text=True, shell=True)
+    proc = pbtools.run_with_stdin([get_gcm_executable(), "get"], input=creds)
 
     if proc.returncode != 0:
         return (None, None)
@@ -239,7 +239,7 @@ def get_credentials():
 
     # force reauthentication
     if cred_dict.get("username") == "PersonalAccessToken":
-        proc = subprocess.run([get_gcm_executable(), "erase"], input=creds, capture_output=True, text=True, shell=True)
+        proc = pbtools.run_with_stdin([get_gcm_executable(), "erase"], input=creds)
         check_remote_connection()
 
     return cred_dict.get("username"), cred_dict.get("password")

--- a/pbpy/pbtools.py
+++ b/pbpy/pbtools.py
@@ -42,6 +42,15 @@ def run_with_output(cmd, env=None):
         env = os.environ | env
     return subprocess.run(cmd, capture_output=True, text=True, shell=True, env=env)
 
+def run_with_stdin(cmd, input, env=None):
+    if os.name == "posix":
+        cmd = " ".join(cmd) if isinstance(cmd, list) else cmd
+
+    if env is None:
+        env = os.environ
+    else:
+        env = os.environ | env
+    return subprocess.run(cmd, input=input, capture_output=True, text=True, shell=True, env=env)
 
 def run_with_combined_output(cmd, env=None):
     if os.name == "posix":


### PR DESCRIPTION
This is similar to commit ca91f0a ("pbpy/pbtools.py: join the command list
in the run() helpers").

Because the 'shell=True' argument is set the commands don't work on Linux
if passed as a Python list.

To address this, we add a run_with_stdin() wrapper that handles the
conversion in the same way, and takes a parameter that is the input from
stdin.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>